### PR TITLE
Integrate hexops/sinter text search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           brew install go-task/tap/go-task
           brew uninstall go@1.17
           brew install go@1.18
-          task install-frontend-deps
+          task setup
       - name: Run tests
         run: task test
       - name: Cross-compile for every OS

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
         uses: arduino/setup-task@v1
       - name: Build Docker image
         run: |
-          task install-frontend-deps
+          task setup
           task build-image
       - name: Record latest release version
         id: recorded_release_version

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs/sinter"]
+	path = libs/sinter
+	url = https://github.com/hexops/sinter

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -105,11 +105,15 @@ tasks:
     desc: Run all tests
     cmds:
       - go test ./...
+    deps:
+      - task: build-zig-debug
 
   test-race:
     desc: Run all tests (checking for race conditions, slow)
     cmds:
       - go test -race ./...
+    deps:
+      - task: build-zig-debug
 
   generate:
     desc: Produce generated code

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -64,22 +64,42 @@ tasks:
     desc: Build .bin/doctree (debug)
     cmds:
       - mkdir -p .bin
-      - go build -o .bin/doctree ./cmd/doctree
+      - go build -a -ldflags "-w" -o .bin/doctree ./cmd/doctree
     sources:
       - ./**/*.go
+      - libs/sinter/**/*.zig
     generates:
       - .bin/doctree
+    deps:
+      - task: build-zig-debug
 
   build-go-release:
     desc: Build .bin/doctree (release)
     cmds:
       - mkdir -p .bin
-      - go build -o .bin/doctree ./cmd/doctree
+      - go build -a -o .bin/doctree ./cmd/doctree
     sources:
       - ./**/*.go
       - ./frontend/public/**
+      - libs/sinter/**/*.zig
     generates:
       - .bin/doctree
+    deps:
+      - task: build-zig-release
+
+  build-zig-debug:
+    desc: Build Zig code in debug mode
+    cmds:
+      - cd libs/sinter && zig build
+    sources:
+      - libs/sinter/**/*.zig
+
+  build-zig-release:
+    desc: Build Zig code in release mode
+    cmds:
+      - cd libs/sinter && zig build -Drelease-fast=true
+    sources:
+      - libs/sinter/**/*.zig
 
   test:
     desc: Run all tests
@@ -117,11 +137,12 @@ tasks:
     deps:
       - build-tools
 
-  install-frontend-deps:
-    desc: Install frontend dependencies
-    dir: frontend
+  setup:
+    desc: Install dependencies, pull submodules
     cmds:
-      - npm install
+      - git submodule update --init --recursive
+      - rm libs/sinter/bindings/sinter-go/go.mod
+      - cd frontend && npm install
 
   build-tools:
     desc: Build tool dependencies (golangci-lint, etc.)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -90,6 +90,7 @@ tasks:
   build-zig-debug:
     desc: Build Zig code in debug mode
     cmds:
+      - rm libs/sinter/bindings/sinter-go/go.mod
       - cd libs/sinter && zig build
     sources:
       - libs/sinter/**/*.zig
@@ -97,6 +98,7 @@ tasks:
   build-zig-release:
     desc: Build Zig code in release mode
     cmds:
+      - rm libs/sinter/bindings/sinter-go/go.mod
       - cd libs/sinter && zig build -Drelease-fast=true
     sources:
       - libs/sinter/**/*.zig
@@ -145,7 +147,6 @@ tasks:
     desc: Install dependencies, pull submodules
     cmds:
       - git submodule update --init --recursive
-      - rm libs/sinter/bindings/sinter-go/go.mod
       - cd frontend && npm install
 
   build-tools:
@@ -180,6 +181,8 @@ tasks:
   cc-x86_64-linux:
     desc: "Cross compile to x86_64-linux using Zig"
     cmds:
+      - rm libs/sinter/bindings/sinter-go/go.mod
+      - cd libs/sinter && zig build -Drelease-fast=true -Dtarget=x86_64-linux
       - go build -o out/doctree-x86_64-linux ./cmd/doctree/
     env:
       CGO_ENABLED: "1"
@@ -198,6 +201,8 @@ tasks:
   cc-x86_64-macos:
     desc: "Cross compile to x86_64-macos using Zig (REQUIRES XCODE, ONLY WORKS ON MACOS)"
     cmds:
+      - rm libs/sinter/bindings/sinter-go/go.mod
+      - cd libs/sinter && zig build -Drelease-fast=true -Dtarget=x86_64-macos
       - go build -o out/doctree-x86_64-macos -buildmode=pie -ldflags "-s -w -linkmode external" ./cmd/doctree/
     env:
       CGO_ENABLED: "1"
@@ -216,6 +221,8 @@ tasks:
   cc-aarch64-macos:
     desc: "Cross compile to aarch64-macos using Zig (REQUIRES XCODE, ONLY WORKS ON MACOS 12+)"
     cmds:
+      - rm libs/sinter/bindings/sinter-go/go.mod
+      - cd libs/sinter && zig build -Drelease-fast=true -Dtarget=aarch64-macos
       - go build -o out/doctree-aarch64-macos -buildmode=pie -ldflags "-s -w -linkmode external" ./cmd/doctree/
     env:
       CGO_ENABLED: "1"
@@ -234,6 +241,8 @@ tasks:
   cc-x86_64-windows:
     desc: "Cross compile to x86_64-windows using Zig"
     cmds:
+      - rm libs/sinter/bindings/sinter-go/go.mod
+      - cd libs/sinter && zig build -Drelease-fast=true -Dtarget=x86_64-windows-gnu
       - go build -o out/doctree-x86_64-windows.exe ./cmd/doctree/
     env:
       CGO_ENABLED: "1"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -90,7 +90,7 @@ tasks:
   build-zig-debug:
     desc: Build Zig code in debug mode
     cmds:
-      - rm libs/sinter/bindings/sinter-go/go.mod
+      - rm -f libs/sinter/bindings/sinter-go/go.mod
       - cd libs/sinter && zig build
     sources:
       - libs/sinter/**/*.zig
@@ -98,7 +98,7 @@ tasks:
   build-zig-release:
     desc: Build Zig code in release mode
     cmds:
-      - rm libs/sinter/bindings/sinter-go/go.mod
+      - rm -f libs/sinter/bindings/sinter-go/go.mod
       - cd libs/sinter && zig build -Drelease-fast=true
     sources:
       - libs/sinter/**/*.zig
@@ -181,7 +181,7 @@ tasks:
   cc-x86_64-linux:
     desc: "Cross compile to x86_64-linux using Zig"
     cmds:
-      - rm libs/sinter/bindings/sinter-go/go.mod
+      - rm -f libs/sinter/bindings/sinter-go/go.mod
       - cd libs/sinter && zig build -Drelease-fast=true -Dtarget=x86_64-linux
       - go build -o out/doctree-x86_64-linux ./cmd/doctree/
     env:
@@ -201,7 +201,7 @@ tasks:
   cc-x86_64-macos:
     desc: "Cross compile to x86_64-macos using Zig (REQUIRES XCODE, ONLY WORKS ON MACOS)"
     cmds:
-      - rm libs/sinter/bindings/sinter-go/go.mod
+      - rm -f libs/sinter/bindings/sinter-go/go.mod
       - cd libs/sinter && zig build -Drelease-fast=true -Dtarget=x86_64-macos
       - go build -o out/doctree-x86_64-macos -buildmode=pie -ldflags "-s -w -linkmode external" ./cmd/doctree/
     env:
@@ -221,7 +221,7 @@ tasks:
   cc-aarch64-macos:
     desc: "Cross compile to aarch64-macos using Zig (REQUIRES XCODE, ONLY WORKS ON MACOS 12+)"
     cmds:
-      - rm libs/sinter/bindings/sinter-go/go.mod
+      - rm -f libs/sinter/bindings/sinter-go/go.mod
       - cd libs/sinter && zig build -Drelease-fast=true -Dtarget=aarch64-macos
       - go build -o out/doctree-aarch64-macos -buildmode=pie -ldflags "-s -w -linkmode external" ./cmd/doctree/
     env:
@@ -241,7 +241,7 @@ tasks:
   cc-x86_64-windows:
     desc: "Cross compile to x86_64-windows using Zig"
     cmds:
-      - rm libs/sinter/bindings/sinter-go/go.mod
+      - rm -f libs/sinter/bindings/sinter-go/go.mod
       - cd libs/sinter && zig build -Drelease-fast=true -Dtarget=x86_64-windows-gnu
       - go build -o out/doctree-x86_64-windows.exe ./cmd/doctree/
     env:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -182,14 +182,14 @@ tasks:
     desc: "Cross compile to x86_64-linux using Zig"
     cmds:
       - rm -f libs/sinter/bindings/sinter-go/go.mod
-      - cd libs/sinter && zig build -Drelease-fast=true -Dtarget=x86_64-linux
+      - cd libs/sinter && zig build -Drelease-fast=true -Dtarget=x86_64-linux-musl
       - go build -o out/doctree-x86_64-linux ./cmd/doctree/
     env:
       CGO_ENABLED: "1"
       GOOS: "linux"
       GOARCH: "amd64"
-      CC: "zig cc -target x86_64-linux-gnu"
-      CXX: "zig c++ -target x86_64-linux-gnu"
+      CC: "zig cc -target x86_64-linux-musl"
+      CXX: "zig c++ -target x86_64-linux-musl"
     sources:
       - ./**/*.go
       - ./frontend/public/**

--- a/cmd/doctree/index.go
+++ b/cmd/doctree/index.go
@@ -47,11 +47,6 @@ Examples:
 			fmt.Printf("%v: indexed %v files (%v bytes) in %v\n", index.Language.ID, index.NumFiles, index.NumBytes, time.Duration(index.DurationSeconds*float64(time.Second)).Round(time.Millisecond))
 		}
 
-		err := indexer.IndexForSearch(*projectFlag, indexes)
-		if err != nil {
-			return errors.Wrap(err, "IndexForSearch")
-		}
-
 		indexDataDir := filepath.Join(*dataDirFlag, "index")
 		writeErr := indexer.WriteIndexes(*projectFlag, indexDataDir, indexes)
 		if indexErr != nil && writeErr != nil {
@@ -60,7 +55,15 @@ Examples:
 		if indexErr != nil {
 			return indexErr
 		}
-		return writeErr
+		if writeErr != nil {
+			return writeErr
+		}
+
+		err := indexer.IndexForSearch(*projectFlag, indexDataDir, indexes)
+		if err != nil {
+			return errors.Wrap(err, "IndexForSearch")
+		}
+		return nil
 	}
 
 	// Register the command.

--- a/cmd/doctree/search.go
+++ b/cmd/doctree/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"path/filepath"
 
 	"github.com/hexops/cmder"
 	"github.com/pkg/errors"
@@ -38,9 +39,8 @@ Examples:
 		query := flagSet.Arg(0)
 
 		ctx := context.Background()
-		_ = dataDirFlag
-		_ = ctx
-		_, err := indexer.Search(query)
+		indexDataDir := filepath.Join(*dataDirFlag, "index")
+		_, err := indexer.Search(ctx, indexDataDir, query)
 		if err != nil {
 			return errors.Wrap(err, "Search")
 		}

--- a/cmd/doctree/search.go
+++ b/cmd/doctree/search.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"path/filepath"
-	"time"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/hexops/cmder"
 	"github.com/pkg/errors"
 
@@ -22,16 +19,15 @@ func init() {
 	const usage = `
 Examples:
 
-  Index all code in the current directory:
+  Search :
 
-    $ doctree index .
+    $ doctree search 'myquery'
 
 `
 
 	// Parse flags for our subcommand.
-	flagSet := flag.NewFlagSet("index", flag.ExitOnError)
+	flagSet := flag.NewFlagSet("search", flag.ExitOnError)
 	dataDirFlag := flagSet.String("data-dir", defaultDataDir(), "where doctree stores its data")
-	projectFlag := flagSet.String("project", defaultProjectName(), "name of the project")
 
 	// Handles calls to our subcommand.
 	handler := func(args []string) error {
@@ -39,28 +35,16 @@ Examples:
 		if flagSet.NArg() != 1 {
 			return &cmder.UsageError{}
 		}
-		dir := flagSet.Arg(0)
+		query := flagSet.Arg(0)
 
 		ctx := context.Background()
-		indexes, indexErr := indexer.IndexDir(ctx, dir)
-		for _, index := range indexes {
-			fmt.Printf("%v: indexed %v files (%v bytes) in %v\n", index.Language.ID, index.NumFiles, index.NumBytes, time.Duration(index.DurationSeconds*float64(time.Second)).Round(time.Millisecond))
-		}
-
-		err := indexer.IndexForSearch(*projectFlag, indexes)
+		_ = dataDirFlag
+		_ = ctx
+		_, err := indexer.Search(query)
 		if err != nil {
-			return errors.Wrap(err, "IndexForSearch")
+			return errors.Wrap(err, "Search")
 		}
-
-		indexDataDir := filepath.Join(*dataDirFlag, "index")
-		writeErr := indexer.WriteIndexes(*projectFlag, indexDataDir, indexes)
-		if indexErr != nil && writeErr != nil {
-			return multierror.Append(indexErr, writeErr)
-		}
-		if indexErr != nil {
-			return indexErr
-		}
-		return writeErr
+		return nil
 	}
 
 	// Register the command.

--- a/cmd/doctree/serve.go
+++ b/cmd/doctree/serve.go
@@ -112,12 +112,9 @@ func Serve(addr, indexDataDir string) error {
 		w.Header().Set("Content-Type", "application/json")
 
 		query := r.URL.Query().Get("query")
-		results, err := indexer.Search(query)
+		results, err := indexer.Search(r.Context(), indexDataDir, query)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		if results == nil {
-			results = []indexer.Result{}
 		}
 
 		b, err := json.Marshal(results)

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@ brew install go-task/tap/go-task
 [Elm](https://elm-lang.org/) and [elm-spa](https://elm-spa.dev):
 
 ```sh
-task install-frontend-deps
+task setup
 ```
 
 *Note*: The frontend dependencies will be installed locally by `npm` in `frontend/`.

--- a/doctree/indexer/golang/indexer.go
+++ b/doctree/indexer/golang/indexer.go
@@ -173,6 +173,7 @@ func (i *goIndexer) IndexDir(ctx context.Context, dir string) (*schema.Index, er
 					ShortLabel: funcName,
 					Label:      funcLabel,
 					Detail:     schema.Markdown(funcDocs),
+					SearchKey:  []string{pkgName, ".", funcName},
 				})
 				functionsByPackage[pkgName] = funcs
 			}
@@ -186,14 +187,16 @@ func (i *goIndexer) IndexDir(ctx context.Context, dir string) (*schema.Index, er
 			ShortLabel: "func",
 			Label:      "Functions",
 			Category:   true,
+			SearchKey:  []string{},
 			Children:   functionsByPackage[pkgName],
 		}
 
 		pages = append(pages, schema.Page{
-			Path:     pkgInfo.path,
-			Title:    "Package " + pkgName,
-			Detail:   schema.Markdown(pkgInfo.docs),
-			Sections: []schema.Section{functionsSection},
+			Path:      pkgInfo.path,
+			Title:     "Package " + pkgName,
+			Detail:    schema.Markdown(pkgInfo.docs),
+			SearchKey: []string{pkgName},
+			Sections:  []schema.Section{functionsSection},
 		})
 	}
 

--- a/doctree/indexer/indexer.go
+++ b/doctree/indexer/indexer.go
@@ -180,7 +180,7 @@ func Get(indexDataDir, projectName string) (map[string]schema.Index, error) {
 		return nil, errors.Wrap(err, "ReadDir")
 	}
 	for _, info := range dir {
-		if !info.IsDir() {
+		if !info.IsDir() && info.Name() != "search-index.sinter" {
 			lang := info.Name()
 
 			f, err := os.Open(filepath.Join(indexDataDir, indexName, lang))

--- a/doctree/indexer/markdown/indexer.go
+++ b/doctree/indexer/markdown/indexer.go
@@ -54,10 +54,11 @@ func (i *markdownIndexer) IndexDir(ctx context.Context, dir string) (*schema.Ind
 		bytes += len(content)
 
 		pages = append(pages, schema.Page{
-			Path:     path,
-			Title:    path,
-			Detail:   schema.Markdown(content),
-			Sections: []schema.Section{},
+			Path:      path,
+			Title:     path,
+			Detail:    schema.Markdown(content),
+			SearchKey: []string{},
+			Sections:  []schema.Section{},
 		})
 	}
 

--- a/doctree/indexer/python/indexer.go
+++ b/doctree/indexer/python/indexer.go
@@ -163,6 +163,7 @@ func (i *pythonIndexer) IndexDir(ctx context.Context, dir string) (*schema.Index
 					ShortLabel: funcName,
 					Label:      funcLabel,
 					Detail:     schema.Markdown(funcDocs),
+					SearchKey:  []string{modName, ".", funcName},
 				})
 				functionsByMod[modName] = funcs
 			}
@@ -175,15 +176,17 @@ func (i *pythonIndexer) IndexDir(ctx context.Context, dir string) (*schema.Index
 			ID:         "func",
 			ShortLabel: "func",
 			Label:      "Functions",
+			SearchKey:  []string{},
 			Category:   true,
 			Children:   functionsByMod[modName],
 		}
 
 		pages = append(pages, schema.Page{
-			Path:     moduleInfo.path,
-			Title:    "Module " + modName,
-			Detail:   schema.Markdown(moduleInfo.docs),
-			Sections: []schema.Section{functionsSection},
+			Path:      moduleInfo.path,
+			Title:     "Module " + modName,
+			Detail:    schema.Markdown(moduleInfo.docs),
+			SearchKey: []string{modName},
+			Sections:  []schema.Section{functionsSection},
 		})
 	}
 

--- a/doctree/indexer/search.go
+++ b/doctree/indexer/search.go
@@ -27,9 +27,12 @@ func IndexForSearch(projectName, indexDataDir string, indexes map[string]*schema
 	defer filter.Deinit()
 
 	walkPage := func(language string, lib schema.Library, p schema.Page, keys []string) []string {
+		key := language + " /-/ " + projectName + " /-/ " + strings.Join(p.SearchKey, "")
+		keys = append(keys, key)
+
 		var walkSection func(s schema.Section)
 		walkSection = func(s schema.Section) {
-			key := language + " / " + lib.Name + " / " + p.Title + " / " + s.ShortLabel
+			key := language + " /-/ " + projectName + " /-/ " + strings.Join(s.SearchKey, "")
 			keys = append(keys, key)
 
 			for _, child := range s.Children {
@@ -184,6 +187,10 @@ func match(query, key string) bool {
 	return false
 }
 
+// TODO: should not be exported, and should take into account language preferences (important
+// punctuation list that is language-specific)
+//
+// TODO: "http.Ge" doesn't match right now, while "http.Get" does. Why?
 func FuzzyKeys(keys []string) []uint64 {
 	var fuzzyKeys []uint64
 	for _, whole := range keys {

--- a/doctree/indexer/search.go
+++ b/doctree/indexer/search.go
@@ -1,0 +1,180 @@
+package indexer
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/doctree/doctree/schema"
+	sinter "github.com/sourcegraph/doctree/libs/sinter/bindings/sinter-go"
+	"github.com/spaolacci/murmur3"
+)
+
+// IndexForSearch produces search indexes for the given project.
+func IndexForSearch(projectName string, indexes map[string]*schema.Index) error {
+	filter, err := sinter.FilterInit(10_000_000)
+	if err != nil {
+		return errors.Wrap(err, "FilterInit")
+	}
+	defer filter.Deinit()
+
+	walkPage := func(language string, lib schema.Library, p schema.Page, keys []string) []string {
+		var walkSection func(s schema.Section)
+		walkSection = func(s schema.Section) {
+			key := language + " / " + lib.Name + " / " + p.Title + " / " + s.ShortLabel
+			keys = append(keys, key)
+
+			for _, child := range s.Children {
+				walkSection(child)
+			}
+		}
+		for _, section := range p.Sections {
+			walkSection(section)
+		}
+		return keys
+	}
+
+	totalNumKeys := 0
+	totalNumSearchKeys := 0
+	insert := func(pagePath string, keys []string) error {
+		totalNumSearchKeys += len(keys)
+		fuzzyKeys := FuzzyKeys(keys)
+		totalNumKeys += len(fuzzyKeys)
+		if err := filter.Insert(&sinter.SliceIterator{Slice: fuzzyKeys}, []byte(pagePath+"\n\n"+strings.Join(keys, "\n")+"\n\n")); err != nil {
+			return errors.Wrap(err, "Insert")
+		}
+		return nil
+	}
+
+	for language, index := range indexes {
+		for _, lib := range index.Libraries {
+			for _, page := range lib.Pages {
+				if err := insert(page.Path, walkPage(language, lib, page, nil)); err != nil {
+					return err
+				}
+				for _, subPage := range page.Subpages {
+					if err := insert(page.Path, walkPage(language, lib, subPage, nil)); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	fmt.Printf("search: indexing %v filter keys (%v search keys)\n", totalNumKeys, totalNumSearchKeys)
+	if err := filter.Index(); err != nil {
+		return errors.Wrap(err, "Index")
+	}
+
+	if err := filter.WriteFile("out.sinter"); err != nil {
+		return errors.Wrap(err, "WriteFile")
+	}
+
+	return nil
+}
+
+func Search(query string) ([]string, error) {
+	t := time.Now()
+	sinterFilter, err := sinter.FilterReadFile("out.sinter")
+	if err != nil {
+		return nil, errors.Wrap(err, "FilterReadFile")
+	}
+	fmt.Println("read file:", time.Since(t))
+	t = time.Now()
+
+	// TODO: query limiting
+	results, err := sinterFilter.QueryLogicalOr([]uint64{hash(query)})
+	if err != nil {
+		return nil, errors.Wrap(err, "QueryLogicalOr")
+	}
+	defer results.Deinit()
+	fmt.Println("found", results.Len(), "in", time.Since(t))
+
+	for _, result := range Results(results, query) {
+		for _, key := range result.Keys {
+			fmt.Println(result.Path, "->", key)
+		}
+	}
+	return nil, nil
+}
+
+type Result struct {
+	Path string
+	Keys []string
+}
+
+func Results(results sinter.FilterResults, query string) []Result {
+	var out []Result
+	for i := 0; i < results.Len(); i++ {
+		lines := strings.Split(string(results.Index(i)), "\n")
+		path := lines[0]
+		keys := lines[2:]
+		var outKeys []string
+		for _, key := range keys {
+			if match(query, key) {
+				outKeys = append(outKeys, key)
+			}
+		}
+		out = append(out, Result{Path: path, Keys: outKeys})
+	}
+	return out
+}
+
+func match(query, key string) bool {
+	for _, part := range append([]string{key}, strings.Split(key, " / ")...) {
+		if strings.HasPrefix(part, query) {
+			return true
+		}
+		if strings.HasSuffix(part, query) {
+			return true
+		}
+		lowerQuery := strings.ToLower(query)
+		if strings.HasPrefix(part, lowerQuery) {
+			return true
+		}
+		if strings.HasSuffix(part, lowerQuery) {
+			return true
+		}
+	}
+	return false
+}
+
+func FuzzyKeys(keys []string) []uint64 {
+	var fuzzyKeys []uint64
+	for _, whole := range keys {
+		for _, part := range append([]string{whole}, strings.Split(whole, " / ")...) {
+			runes := []rune(part)
+			fuzzyKeys = append(fuzzyKeys, prefixKeys(runes)...)
+			fuzzyKeys = append(fuzzyKeys, suffixKeys(runes)...)
+			lowerRunes := []rune(strings.ToLower(part))
+			fuzzyKeys = append(fuzzyKeys, prefixKeys(lowerRunes)...)
+			fuzzyKeys = append(fuzzyKeys, suffixKeys(lowerRunes)...)
+		}
+	}
+	return fuzzyKeys
+}
+
+func prefixKeys(runes []rune) []uint64 {
+	var keys []uint64
+	var prefix []rune
+	for _, r := range runes {
+		prefix = append(prefix, r)
+		keys = append(keys, hash(string(prefix)))
+	}
+	return keys
+}
+
+func suffixKeys(runes []rune) []uint64 {
+	var keys []uint64
+	var suffix []rune
+	for i := len(runes) - 1; i >= 0; i-- {
+		suffix = append([]rune{runes[i]}, suffix...)
+		keys = append(keys, hash(string(suffix)))
+	}
+	return keys
+}
+
+func hash(s string) uint64 {
+	return murmur3.Sum64([]byte(s))
+}

--- a/doctree/schema/schema.go
+++ b/doctree/schema/schema.go
@@ -95,6 +95,18 @@ type Page struct {
 	// The detail
 	Detail Markdown `json:"detail"`
 
+	// SearchKey describes a single string a user would type in to a search bar to find this
+	// page. For example, in Go this might be "net/http"
+	//
+	// This is a list of strings to diffentiate the different "parts" of the string, for Go it would
+	// actually be ["net", "/", "http"]. The search engine will do fuzzy prefix/suffix matching of
+	// each *part* of the key. For example, a query for "net" would be treated as "*net*".
+	//
+	// The key should aim to be unique within the scope of the directory and language that was
+	// indexed (you can imagine the key is prefixed with the language name and directory/repository
+	// name for you.)
+	SearchKey []string `json:"searchKey"`
+
 	// Sections on the page.
 	Sections []Section `json:"sections"`
 
@@ -135,6 +147,19 @@ type Section struct {
 
 	// The detail
 	Detail Markdown `json:"detail"`
+
+	// SearchKey describes a single string a user would type in to a search bar to find this
+	// section. For example, in Go this might be "net/http.Client.PostForm"
+	//
+	// This is a list of strings to diffentiate the different "parts" of the string, for Go it would
+	// actually be ["net", "/", "http", ".", "Client", ".", "PostForm"]. The search engine will do
+	// fuzzy prefix/suffix matching of each *part* of the key. For example, a query for
+	// "net.PostForm" would be treated as "*net*.*PostForm*".
+	//
+	// The key should aim to be unique within the scope of the directory and language that was
+	// indexed (you can imagine the key is prefixed with the language name and directory/repository
+	// name for you.)
+	SearchKey []string `json:"searchKey"`
 
 	// Any children sections. For example, if this section represents a class the children could be
 	// the methods of the class and they would be rendered immediately below this section and

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -6,6 +6,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;1,500;1,800&display=swap" rel="stylesheet"> 
+  <link href="/stylesheet.css" rel="stylesheet"> 
 </head>
 <body>
   <!--
@@ -31,79 +32,5 @@
 
   <script src="/dist/elm.js"></script>
   <script> Elm.Main.init() </script>
-
-  <style>
-.markdown {
-  font-family: Verdana, Geneva, sans-serif;
-  font-size: 18px;
-  line-height: 1.3;
-  white-space: normal;
-}
-.markdown pre {
-  width: 100%;
-  white-space: pre-wrap;
-  padding: 1rem;
-}
-.markdown code {
-  padding: 0.15rem;
-  margin: 0.1rem;
-  display: inline-block;
-}
-.markdown code, .markdown pre {
-  font-family: "JetBrains Mono", monospace;
-  font-size: 16px;
-  background: #e6e3e3;
-}
-.markdown pre>code {
-  background: none;
-  padding: 0;
-}
-.markdown p + p, .markdown table + p {
-  margin-top: 1rem;
-}
-.markdown p {
-  margin: 0;
-}
-.markdown img {
-  max-width: 100%;
-}
-.markdown table {
-    margin-top: 1rem;
-    border-collapse: collapse;
-    width: calc(100% - 2rem - 2rem);
-    margin-left: 2rem;
-}
-.markdown thead {
-    border-bottom: 1px solid gray;
-}
-.markdown td, th {
-    padding: 0.5rem;
-}
-.markdown tr:nth-child(even) {
-    background: #f0f0f0;
-}
-.markdown th {
-    padding-top: 1rem;
-    padding-bottom: 1rem;
-    text-align: left;
-}
-.markdown table code {
-  background: 0;
-  padding: 0;
-}
-.markdown blockquote {
-  margin: 1rem;
-  margin-left: 0.5rem;
-  padding: 0.5rem;
-  border-left: 3px solid #d2d2d2;
-}
-.markdown hr {
-  height: 2px;
-  background: #b7b7b7;
-  border: 0;
-  width: 100%;
-}
-
-  </style>
 </body>
 </html>

--- a/frontend/public/stylesheet.css
+++ b/frontend/public/stylesheet.css
@@ -1,0 +1,70 @@
+.markdown {
+  font-family: Verdana, Geneva, sans-serif;
+  font-size: 18px;
+  line-height: 1.3;
+  white-space: normal;
+}
+.markdown pre {
+  width: 100%;
+  white-space: pre-wrap;
+  padding: 1rem;
+}
+.markdown code {
+  padding: 0.15rem;
+  margin: 0.1rem;
+  display: inline-block;
+}
+.markdown code, .markdown pre {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 16px;
+  background: #e6e3e3;
+}
+.markdown pre>code {
+  background: none;
+  padding: 0;
+}
+.markdown p + p, .markdown table + p {
+  margin-top: 1rem;
+}
+.markdown p {
+  margin: 0;
+}
+.markdown img {
+  max-width: 100%;
+}
+.markdown table {
+    margin-top: 1rem;
+    border-collapse: collapse;
+    width: calc(100% - 2rem - 2rem);
+    margin-left: 2rem;
+}
+.markdown thead {
+    border-bottom: 1px solid gray;
+}
+.markdown td, th {
+    padding: 0.5rem;
+}
+.markdown tr:nth-child(even) {
+    background: #f0f0f0;
+}
+.markdown th {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    text-align: left;
+}
+.markdown table code {
+  background: 0;
+  padding: 0;
+}
+.markdown blockquote {
+  margin: 1rem;
+  margin-left: 0.5rem;
+  padding: 0.5rem;
+  border-left: 3px solid #d2d2d2;
+}
+.markdown hr {
+  height: 2px;
+  background: #b7b7b7;
+  border: 0;
+  width: 100%;
+}

--- a/frontend/src/APISchema.elm
+++ b/frontend/src/APISchema.elm
@@ -39,11 +39,15 @@ projectIndexesDecoder =
 searchResultDecoder : Decoder SearchResult
 searchResultDecoder =
     Decode.succeed SearchResult
+        |> Pipeline.required "language" Decode.string
+        |> Pipeline.required "projectName" Decode.string
+        |> Pipeline.required "searchKey" Decode.string
         |> Pipeline.required "path" Decode.string
-        |> Pipeline.required "keys" (Decode.list Decode.string)
 
 
 type alias SearchResult =
-    { path : String
-    , keys : List String
+    { language : String
+    , projectName : String
+    , searchKey : String
+    , path : String
     }

--- a/frontend/src/APISchema.elm
+++ b/frontend/src/APISchema.elm
@@ -1,0 +1,49 @@
+module APISchema exposing (..)
+
+import Dict exposing (Dict)
+import Json.Decode as Decode exposing (Decoder)
+import Json.Decode.Pipeline as Pipeline
+import Schema
+
+
+
+-- decoder for: /api/list
+
+
+type alias ProjectList =
+    List String
+
+
+projectListDecoder : Decoder ProjectList
+projectListDecoder =
+    Decode.list Decode.string
+
+
+
+-- decoder for: /api/get?name=github.com/sourcegraph/sourcegraph
+
+
+type alias ProjectIndexes =
+    Dict String Schema.Index
+
+
+projectIndexesDecoder : Decoder ProjectIndexes
+projectIndexesDecoder =
+    Decode.dict Schema.indexDecoder
+
+
+
+-- decoder for: /api/search?query=foobar
+
+
+searchResultDecoder : Decoder SearchResult
+searchResultDecoder =
+    Decode.succeed SearchResult
+        |> Pipeline.required "path" Decode.string
+        |> Pipeline.required "keys" (Decode.list Decode.string)
+
+
+type alias SearchResult =
+    { path : String
+    , keys : List String
+    }

--- a/frontend/src/Pages/Home_.elm
+++ b/frontend/src/Pages/Home_.elm
@@ -227,20 +227,19 @@ searchResults request =
         Just response ->
             case response of
                 Ok results ->
-                    E.column [] (List.map (\result -> E.text result) (flattenResults results))
+                    E.column []
+                        (List.map
+                            (\r ->
+                                E.link []
+                                    { url = Url.Builder.absolute [ r.projectName, "-", r.language, "-", r.path ] []
+                                    , label = E.el [ Font.underline ] (E.text r.searchKey)
+                                    }
+                            )
+                            results
+                        )
 
                 Err err ->
                     E.text (httpErrorToString err)
 
         Nothing ->
             E.text "loading.."
-
-
-flattenResult : APISchema.SearchResult -> List String
-flattenResult result =
-    List.map (\key -> String.concat [ result.path, " : ", key ]) result.keys
-
-
-flattenResults : List APISchema.SearchResult -> List String
-flattenResults results =
-    List.concat (List.map (\result -> flattenResult result) results)

--- a/frontend/src/ProjectPage.elm
+++ b/frontend/src/ProjectPage.elm
@@ -1,5 +1,6 @@
 module ProjectPage exposing (Model, Msg, init, page, subscriptions, update, view)
 
+import APISchema
 import Dict exposing (keys)
 import Effect exposing (Effect)
 import Element as E
@@ -163,7 +164,7 @@ view shared projectURI model =
     }
 
 
-viewName : Model -> Schema.ProjectIndexes -> String -> Html Msg
+viewName : Model -> APISchema.ProjectIndexes -> String -> Html Msg
 viewName model projectIndexes projectName =
     E.layout Style.layout
         (E.column []
@@ -181,7 +182,7 @@ viewName model projectIndexes projectName =
         )
 
 
-viewNameLanguage : Model -> Schema.ProjectIndexes -> String -> String -> Html Msg
+viewNameLanguage : Model -> APISchema.ProjectIndexes -> String -> String -> Html Msg
 viewNameLanguage model projectIndexes projectName language =
     let
         firstLanguage =
@@ -246,7 +247,7 @@ viewNameLanguage model projectIndexes projectName language =
             E.layout Style.layout (E.text "language not found")
 
 
-viewNameLanguagePage : Model -> Schema.ProjectIndexes -> String -> String -> String -> Html Msg
+viewNameLanguagePage : Model -> APISchema.ProjectIndexes -> String -> String -> String -> Html Msg
 viewNameLanguagePage model projectIndexes projectName language targetPagePath =
     let
         pageLookup =

--- a/frontend/src/Schema.elm
+++ b/frontend/src/Schema.elm
@@ -88,6 +88,7 @@ pageDecoder =
         |> Pipeline.required "path" Decode.string
         |> Pipeline.required "title" Decode.string
         |> Pipeline.required "detail" Decode.string
+        |> Pipeline.required "searchKey" (Decode.list Decode.string)
         |> Pipeline.required "sections" (Decode.lazy (\_ -> sectionsDecoder))
         |> Pipeline.optional "subpages" (Decode.lazy (\_ -> pagesDecoder)) (Pages [])
 
@@ -100,6 +101,16 @@ type alias Page =
       title : String
     , -- The detail
       detail : Markdown
+
+    -- SearchKey describes a single string a user would type in to a search bar to find this
+    -- page. For example, in Go this might be "net/http"
+    -- This is a list of strings to diffentiate the different "parts" of the string, for Go it would
+    -- actually be ["net", "/", "http"]. The search engine will do fuzzy prefix/suffix matching of
+    -- each *part* of the key. For example, a query for "net" would be treated as "*net*".
+    -- The key should aim to be unique within the scope of the directory and language that was
+    -- indexed (you can imagine the key is prefixed with the language name and directory/repository
+    -- name for you.)
+    , searchKey : List String
     , -- Sections of the page.
       sections : Sections
     , -- Subpages of this one.
@@ -123,6 +134,7 @@ sectionDecoder =
         |> Pipeline.required "shortLabel" Decode.string
         |> Pipeline.required "label" Decode.string
         |> Pipeline.required "detail" Decode.string
+        |> Pipeline.required "searchKey" (Decode.list Decode.string)
         |> Pipeline.optional "children" (Decode.lazy (\_ -> sectionsDecoder)) (Sections [])
 
 
@@ -141,6 +153,19 @@ type alias Section =
       label : Markdown
     , -- The detail
       detail : Markdown
+
+    -- SearchKey describes a single string a user would type in to a search bar to find this
+    -- section. For example, in Go this might be "net/http.Client.PostForm"
+    --
+    -- This is a list of strings to diffentiate the different "parts" of the string, for Go it would
+    -- actually be ["net", "/", "http", ".", "Client", ".", "PostForm"]. The search engine will do
+    -- fuzzy prefix/suffix matching of each *part* of the key. For example, a query for
+    -- "net.PostForm" would be treated as "*net*.*PostForm*".
+    --
+    -- The key should aim to be unique within the scope of the directory and language that was
+    -- indexed (you can imagine the key is prefixed with the language name and directory/repository
+    -- name for you.)
+    , searchKey : List String
     , -- Any children sections. For example, if this section represents a class the children could be
       -- the methods of the class and they would be rendered immediately below this section and
       -- indicated as being children of the parent section.

--- a/frontend/src/Schema.elm
+++ b/frontend/src/Schema.elm
@@ -1,34 +1,7 @@
 module Schema exposing (..)
 
-import Dict exposing (Dict)
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline as Pipeline
-
-
-
--- decoder for: /api/list
-
-
-type alias ProjectList =
-    List String
-
-
-projectListDecoder : Decoder ProjectList
-projectListDecoder =
-    Decode.list Decode.string
-
-
-
--- decoder for: /api/get?name=github.com/sourcegraph/sourcegraph
-
-
-type alias ProjectIndexes =
-    Dict String Index
-
-
-projectIndexesDecoder : Decoder ProjectIndexes
-projectIndexesDecoder =
-    Decode.dict indexDecoder
 
 
 indexDecoder : Decoder Index

--- a/frontend/src/Shared.elm
+++ b/frontend/src/Shared.elm
@@ -7,10 +7,10 @@ module Shared exposing
     , update
     )
 
+import APISchema
 import Http
 import Json.Decode as Json
 import Request exposing (Request)
-import Schema
 import Url.Builder
 
 
@@ -20,13 +20,13 @@ type alias Flags =
 
 type alias Model =
     { currentProjectName : Maybe String
-    , projectIndexes : Maybe (Result Http.Error Schema.ProjectIndexes)
+    , projectIndexes : Maybe (Result Http.Error APISchema.ProjectIndexes)
     }
 
 
 type Msg
     = GetProject String
-    | GotProject (Result Http.Error Schema.ProjectIndexes)
+    | GotProject (Result Http.Error APISchema.ProjectIndexes)
 
 
 init : Request -> Flags -> ( Model, Cmd Msg )
@@ -56,7 +56,7 @@ update _ msg model =
                 ( { model | currentProjectName = Just projectName }
                 , Http.get
                     { url = Url.Builder.absolute [ "api", "get" ] [ Url.Builder.string "name" projectName ]
-                    , expect = Http.expectJson GotProject Schema.projectIndexesDecoder
+                    , expect = Http.expectJson GotProject APISchema.projectIndexesDecoder
                     }
                 )
                 -- Loaded already

--- a/frontend/src/Style.elm
+++ b/frontend/src/Style.elm
@@ -3,8 +3,6 @@ module Style exposing (..)
 import Element as E
 import Element.Font as Font
 import Element.Region as Region
-import Html
-import Html.Attributes
 
 
 font =

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/OpenPeeDeeP/depguard v1.1.0 // indirect
+	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/alexkohler/prealloc v1.0.0 // indirect
 	github.com/ashanbrown/forbidigo v1.3.0 // indirect
 	github.com/ashanbrown/makezero v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -121,6 +121,7 @@ require (
 	github.com/smacker/go-tree-sitter v0.0.0-20220404154745-d5f0a70b82af // indirect
 	github.com/sonatard/noctx v0.0.1 // indirect
 	github.com/sourcegraph/go-diff v0.6.1 // indirect
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/cobra v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -654,6 +654,8 @@ github.com/sonatard/noctx v0.0.1/go.mod h1:9D2D/EoULe8Yy2joDHJj7bv3sZoq9AaSb8B4l
 github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=
 github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
+github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMo
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OpenPeeDeeP/depguard v1.1.0 h1:pjK9nLPS1FwQYGGpPxoMYpe7qACHOhAWQMQzV71i49o=
 github.com/OpenPeeDeeP/depguard v1.1.0/go.mod h1:JtAMzWkmFEzDPyAd+W0NHl1lvpQKTvT9jnRVsohBKpc=
+github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
+github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -79,6 +81,7 @@ github.com/alexkohler/prealloc v1.0.0/go.mod h1:VetnK3dIgFBBKmg0YnD9F9x6Icjd+9cv
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -152,6 +155,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/denis-tingaikin/go-header v0.4.3 h1:tEaZKAlqql6SKCY++utLmkPLd6K8IBM20Ha7UVm+mtU=
 github.com/denis-tingaikin/go-header v0.4.3/go.mod h1:0wOCWuN71D5qIgE2nz9KrKmuYBAC2Mra5RassOIQ2/c=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
This is a proposal PR to integrate [hexops/sinter](https://github.com/hexops/sinter) text search (my personal research project done outside Sourcegraph) into doctree to provide fuzzy as-you-type symbols search.

Helps #16

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received 
permission to do so by an employer or client I am producing work for whom has this right.
