### PR TITLE
Create data directory if it does not exist before creating autoindex file

### DIFF
--- a/doctree/indexer/cli.go
+++ b/doctree/indexer/cli.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 )
@@ -27,6 +28,11 @@ func ReadAutoIndex(path string) (map[string]AutoIndexedProject, error) {
 	autoIndexedProjects := make(map[string]AutoIndexedProject)
 	data, err := os.ReadFile(path)
 	if err != nil {
+		if _, err := os.Stat(filepath.Dir(path)); os.IsNotExist(err) {
+			if err := os.Mkdir(filepath.Dir(path), os.ModePerm); err != nil {
+				return nil, errors.Wrap(err, "CreateAutoIndexDirectory")
+			}
+		}
 		if os.IsNotExist(err) {
 			_, err := os.Create(path)
 			if err != nil {


### PR DESCRIPTION
Fixes #31 

This PR makes sure that the data directory exists on homeDir by creating it first before the step of creating autoindex file. 
![task-setup-mkdir-2](https://user-images.githubusercontent.com/7043511/169654099-764dd292-6961-4190-99e3-f4b0fd24cbb3.JPG)


- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.
