### PR TITLE
automatic reindexing on doctree.org + automatic migrations

### DIFF
--- a/cmd/doctree/serve.go
+++ b/cmd/doctree/serve.go
@@ -504,7 +504,7 @@ func AutoIndexRepositories(dataDir, indexDataDir string) error {
 	for {
 		time.Sleep(1 * time.Minute)
 
-		projects, err := indexer.List(dataDir)
+		projects, err := indexer.List(indexDataDir)
 		if err != nil {
 			return errors.Wrap(err, "List")
 		}

--- a/cmd/doctree/serve.go
+++ b/cmd/doctree/serve.go
@@ -55,6 +55,11 @@ Examples:
 		signals := make(chan os.Signal, 1)
 		signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 
+		err := indexer.RunMigrations(context.Background(), *cloudModeFlag, *dataDirFlag, indexDataDir)
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		go Serve(*cloudModeFlag, *httpFlag, *dataDirFlag, indexDataDir)
 		go func() {
 			err := ListenAutoIndexedProjects(dataDirFlag)

--- a/cmd/doctree/util.go
+++ b/cmd/doctree/util.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/doctree/doctree/git"
 )
 
 func getGitURIForFile(dir string) (string, error) {
@@ -57,7 +58,7 @@ func defaultDataDir() string {
 }
 
 func defaultProjectName(defaultDir string) string {
-	uri, err := getGitURIForFile(defaultDir)
+	uri, err := git.URIForFile(defaultDir)
 	if err != nil {
 		absDir, err := filepath.Abs(defaultDir)
 		if err != nil {

--- a/cmd/doctree/util.go
+++ b/cmd/doctree/util.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"fmt"
-	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -12,41 +10,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/doctree/doctree/git"
 )
-
-func getGitURIForFile(dir string) (string, error) {
-	cmd := exec.Command("git", "config", "--get", "remote.origin.url")
-	absDir, err := filepath.Abs(dir)
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to get absolute path for %s", dir)
-	}
-	cmd.Dir = absDir
-	out, err := cmd.Output()
-	if err != nil {
-		return "", errors.Wrapf(err, "git config --get remote.origin.url (pwd=%s)", cmd.Dir)
-	}
-	gitURL, err := normalizeGitURL(strings.TrimSpace(string(out)))
-	if err != nil {
-		return "", errors.Wrap(err, "normalizeGitURL")
-	}
-	return gitURL, nil
-}
-
-func normalizeGitURL(gitURL string) (string, error) {
-	s := gitURL
-	if strings.HasPrefix(gitURL, "git@") {
-		s = strings.Replace(s, ":", "/", 1)
-		s = strings.Replace(s, "git@", "git://", 1) // dummy scheme
-	}
-
-	u, err := url.Parse(s)
-	if err != nil {
-		return "", err
-	}
-	p := u.Path
-	p = strings.TrimSuffix(p, ".git")
-	p = strings.TrimPrefix(p, "/")
-	return fmt.Sprintf("%s/%s", u.Hostname(), p), nil
-}
 
 func defaultDataDir() string {
 	home, err := os.UserHomeDir()

--- a/doctree/git/git.go
+++ b/doctree/git/git.go
@@ -44,3 +44,22 @@ func normalizeGitURL(gitURL string) (string, error) {
 	p = strings.TrimPrefix(p, "/")
 	return fmt.Sprintf("%s/%s", u.Hostname(), p), nil
 }
+
+func RevParse(dir string, abbrefRef bool, rev string) (string, error) {
+	var cmd *exec.Cmd
+	if abbrefRef {
+		cmd = exec.Command("git", "rev-parse", "--abbrev-ref", rev)
+	} else {
+		cmd = exec.Command("git", "rev-parse", "--get", rev)
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get absolute path for %s", dir)
+	}
+	cmd.Dir = absDir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", errors.Wrapf(err, "git rev-parse ... (pwd=%s)", cmd.Dir)
+	}
+	return string(out), nil
+}

--- a/doctree/git/git.go
+++ b/doctree/git/git.go
@@ -1,0 +1,46 @@
+package git
+
+import (
+	"fmt"
+	"net/url"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func URIForFile(dir string) (string, error) {
+	cmd := exec.Command("git", "config", "--get", "remote.origin.url")
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get absolute path for %s", dir)
+	}
+	cmd.Dir = absDir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", errors.Wrapf(err, "git config --get remote.origin.url (pwd=%s)", cmd.Dir)
+	}
+	gitURL, err := normalizeGitURL(strings.TrimSpace(string(out)))
+	if err != nil {
+		return "", errors.Wrap(err, "normalizeGitURL")
+	}
+	return gitURL, nil
+}
+
+func normalizeGitURL(gitURL string) (string, error) {
+	s := gitURL
+	if strings.HasPrefix(gitURL, "git@") {
+		s = strings.Replace(s, ":", "/", 1)
+		s = strings.Replace(s, "git@", "git://", 1) // dummy scheme
+	}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", err
+	}
+	p := u.Path
+	p = strings.TrimSuffix(p, ".git")
+	p = strings.TrimPrefix(p, "/")
+	return fmt.Sprintf("%s/%s", u.Hostname(), p), nil
+}

--- a/doctree/indexer/golang/indexer.go
+++ b/doctree/indexer/golang/indexer.go
@@ -406,7 +406,6 @@ func (i *goIndexer) IndexDir(ctx context.Context, dir string) (*schema.Index, er
 		Libraries: []schema.Library{
 			{
 				Name:        "TODO",
-				Repository:  "TODO",
 				ID:          "TODO",
 				Version:     "TODO",
 				VersionType: "TODO",

--- a/doctree/indexer/indexer.go
+++ b/doctree/indexer/indexer.go
@@ -166,7 +166,7 @@ func List(indexDataDir string) ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "ReadDir")
 	}
-	var indexes []string
+	indexes := []string{}
 	for _, info := range dir {
 		if info.IsDir() {
 			indexes = append(indexes, decodeProjectName(info.Name()))

--- a/doctree/indexer/indexer.go
+++ b/doctree/indexer/indexer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/doctree/doctree/apischema"
+	"github.com/sourcegraph/doctree/doctree/git"
 	"github.com/sourcegraph/doctree/doctree/schema"
 )
 
@@ -95,6 +96,9 @@ func IndexDir(ctx context.Context, dir string) (map[string]*schema.Index, error)
 				start := time.Now()
 				index, err := indexer.IndexDir(ctx, dir)
 				if index != nil {
+					index.GitRepository, _ = git.URIForFile(dir)
+					index.GitCommitID, _ = git.RevParse(dir, false, "HEAD")
+					index.GitRefName, _ = git.RevParse(dir, true, "HEAD")
 					index.DurationSeconds = time.Since(start).Seconds()
 					index.CreatedAt = time.Now().Format(time.RFC3339)
 					index.Directory = absDir
@@ -344,7 +348,7 @@ func RunIndexers(ctx context.Context, dir, dataDir, projectName string) error {
 // this file is how we'd determine which directories need to be re-indexed / removed.
 //
 // An incrementing integer. No relation to other version numbers.
-const projectDirVersion = "1"
+const projectDirVersion = "2"
 
 // The version stored in e.g. ~/.doctree/version - indicating the version of the overall data
 // directory. If we need to change the directory structure in some way, change the autoindex file

--- a/doctree/indexer/markdown/indexer.go
+++ b/doctree/indexer/markdown/indexer.go
@@ -67,7 +67,6 @@ func (i *markdownIndexer) IndexDir(ctx context.Context, dir string) (*schema.Ind
 		Libraries: []schema.Library{
 			{
 				Name:        "TODO",
-				Repository:  "TODO",
 				ID:          "TODO",
 				Version:     "TODO",
 				VersionType: "TODO",

--- a/doctree/indexer/python/indexer.go
+++ b/doctree/indexer/python/indexer.go
@@ -251,7 +251,6 @@ func (i *pythonIndexer) IndexDir(ctx context.Context, dir string) (*schema.Index
 func getFunctions(node *sitter.Node, content []byte, q string, searchKeyPrefix []string) ([]schema.Section, error) {
 	var functions []schema.Section
 	query, err := sitter.NewQuery([]byte(q), python.GetLanguage())
-
 	if err != nil {
 		return nil, errors.Wrap(err, "NewQuery")
 	}

--- a/doctree/indexer/python/indexer.go
+++ b/doctree/indexer/python/indexer.go
@@ -238,7 +238,6 @@ func (i *pythonIndexer) IndexDir(ctx context.Context, dir string) (*schema.Index
 		Libraries: []schema.Library{
 			{
 				Name:        "TODO",
-				Repository:  "TODO",
 				ID:          "TODO",
 				Version:     "TODO",
 				VersionType: "TODO",

--- a/doctree/indexer/zig/indexer.go
+++ b/doctree/indexer/zig/indexer.go
@@ -301,7 +301,6 @@ func (i *zigIndexer) IndexDir(ctx context.Context, dir string) (*schema.Index, e
 		Libraries: []schema.Library{
 			{
 				Name:        "TODO",
-				Repository:  "TODO",
 				ID:          "TODO",
 				Version:     "TODO",
 				VersionType: "TODO",

--- a/doctree/schema/schema.go
+++ b/doctree/schema/schema.go
@@ -16,6 +16,26 @@ type Index struct {
 	// Directory that was indexed (absolute path.)
 	Directory string `json:"directory"`
 
+	// GitRepository is the normalized Git repository URI. e.g. "https://github.com/golang/go" or
+	// "git@github.com:golang/go" - the same value reported by `git config --get remote.origin.url`
+	// with `git@github.com:foo/bar` rewritten to `git://github.com/foo/bar`, credentials removed,
+	// any ".git" suffix removed, and any leading "/" prefix removed.
+	//
+	// Empty string if the indexed directory was not a Git repository.
+	GitRepository string `json:"gitRepository"`
+
+	// GitCommitID is the SHA commit hash of the Git repository revision at the time of indexing, as
+	// reported by `git rev-parse HEAD`.
+	//
+	// Empty string if the indexed directory was not a Git repository.
+	GitCommitID string `json:"gitCommitID"`
+
+	// GitRefName is the current Git ref name (branch name, tag name, etc.) as reported by
+	// `git rev-parse --abbrev-ref HEAD`
+	//
+	// Empty string if the indexed directory was not a Git repository.
+	GitRefName string `json:"gitRefName"`
+
 	// CreatedAt time of the index (RFC3339)
 	CreatedAt string `json:"createdAt"`
 
@@ -62,10 +82,6 @@ var (
 type Library struct {
 	// Name of the library
 	Name string `json:"name"`
-
-	// Repository the documentation lives in, a Git remote URL. e.g. "https://github.com/golang/go"
-	// or "git@github.com:golang/go"
-	Repository string `json:"repository"`
 
 	// ID of this repository. Many languages have a unique identifier, for example in Java this may
 	// be "com.google.android.webview" in Python it may be the PyPi package name. For Rust, the

--- a/frontend/src/Project.elm
+++ b/frontend/src/Project.elm
@@ -134,15 +134,7 @@ sidebarScrollIntoView sectionID =
                     (Browser.Dom.getElement id)
             )
         |> Task.andThen (\y -> Browser.Dom.setViewportOf "sidebar-area" 0 y)
-        |> Task.attempt
-            (\result ->
-                case result of
-                    Ok _ ->
-                        NoOp
-
-                    Err err ->
-                        NoOp
-            )
+        |> Task.attempt (\_ -> NoOp)
 
 
 

--- a/frontend/src/Schema.elm
+++ b/frontend/src/Schema.elm
@@ -9,6 +9,9 @@ indexDecoder =
     Decode.succeed Index
         |> Pipeline.required "schemaVersion" Decode.string
         |> Pipeline.required "directory" Decode.string
+        |> Pipeline.required "gitRepository" Decode.string
+        |> Pipeline.required "gitCommitID" Decode.string
+        |> Pipeline.required "gitRefName" Decode.string
         |> Pipeline.required "createdAt" Decode.string
         |> Pipeline.required "numFiles" Decode.int
         |> Pipeline.required "numBytes" Decode.int
@@ -22,6 +25,22 @@ type alias Index =
       schemaVersion : String
     , -- Directory that was indexed (absolute path.)
       directory : String
+    , -- GitRepository is the normalized Git repository URI. e.g. "https://github.com/golang/go" or
+      -- "git@github.com:golang/go" - the same value reported by `git config --get remote.origin.url`
+      -- with `git@github.com:foo/bar` rewritten to `git://github.com/foo/bar`, credentials removed,
+      -- any ".git" suffix removed, and any leading "/" prefix removed.
+      --
+      -- Empty string if the indexed directory was not a Git repository.
+      gitRepository : String
+    , -- GitCommitID is the SHA commit hash of the Git repository revision at the time of indexing, as
+      -- reported by `git rev-parse HEAD`.
+      --
+      -- Empty string if the indexed directory was not a Git repository.
+      gitCommitID : String
+    , -- GitRefName is the current Git ref name (branch name, tag name, etc.) as reported by `git rev-parse --abbrev-ref HEAD`
+      --
+      -- Empty string if the indexed directory was not a Git repository.
+      gitRefName : String
     , -- CreatedAt time of the index (RFC3339)
       createdAt : String
     , -- NumFiles indexed.
@@ -56,7 +75,6 @@ libraryDecoder : Decoder Library
 libraryDecoder =
     Decode.succeed Library
         |> Pipeline.required "name" Decode.string
-        |> Pipeline.required "repository" Decode.string
         |> Pipeline.required "id" Decode.string
         |> Pipeline.required "version" Decode.string
         |> Pipeline.required "versionType" Decode.string
@@ -66,9 +84,6 @@ libraryDecoder =
 type alias Library =
     { -- Name of the library
       name : String
-    , -- Repository the documentation lives in, a Git remote URL. e.g. "https://github.com/golang/go"
-      -- or "git@github.com:golang/go"
-      repository : String
     , -- ID of this repository. Many languages have a unique identifier, for example in Java this may
       -- be "com.google.android.webview" in Python it may be the PyPi package name. For Rust, the
       -- Cargo crate name, etc.


### PR DESCRIPTION
## Automatic migrations

Before this change, if say the Python indexer improved and you launched a new version of `doctree` you would need to reindex your projects to see the improvement.

Similarly, if the doctree schema format changes, you might see errors until you reindex your projects.

Now when we improve indexers, add new indexers, change the schema format, etc. we just bump `indexer.projectDirVersion` and then on startup you'll see:

```
2022/05/30 17:58:00 migration: doctree schema has changed, removing: github.com/Sobeston/ziglearn
2022/05/30 17:58:00 migration: doctree schema has changed, removing: github.com/django/django
2022/05/30 17:58:00 migration: doctree schema has changed, removing: github.com/golang/go
2022/05/30 17:58:00 migration: doctree schema has changed, removing: github.com/gorilla/mux
2022/05/30 17:58:00 migration: doctree schema has changed, removing: github.com/hexops/mach
2022/05/30 17:58:00 migration: doctree schema has changed, removing: github.com/sourcegraph/sourcegraph
```

If you used auto indexing to add the projects, they should be auto-indexed again. If not, you'll need to rerun `doctree index .` on them - it's now clear you need to do so.

In cloud mode, it will automatically reclone the repository and index it (since we know the source.)

## Automatic reindexing on doctree.org

Right now the repositories on doctree.org can become quite out of date, since they only index once (and when I redeploy the site.) Now there is a silly for loop here that will reindex them when new commits are pushed to the Git repos - so they should pretty much always be up to date now.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received 
permission to do so by an employer or client I am producing work for whom has this right.
