### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: task cross-compile
       - name: Record latest release version
         id: recorded_release_version
-        run: echo "::set-output name=commit::$(git log --oneline | head -n1 | cut -d " " -f1)"
+        run: echo "commit=$(git log --oneline | head -n1 | cut -d " " -f1)" >> "$GITHUB_OUTPUT"
       - name: Release
         if: success() && github.ref == 'refs/heads/main' && github.event_Name == 'push' && github.repository == 'sourcegraph/doctree'
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
           task build-image
       - name: Record latest release version
         id: recorded_release_version
-        run: echo "::set-output name=commit::$(git log --oneline | head -n1 | cut -d " " -f1)"
+        run: echo "commit=$(git log --oneline | head -n1 | cut -d " " -f1)" >> "$GITHUB_OUTPUT"
       - name: Publish Docker image
         if: success() && github.ref == 'refs/heads/main' && github.repository == 'sourcegraph/doctree'
         run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter